### PR TITLE
#8 feature create transaction list with delete

### DIFF
--- a/PocketPulse/iOS/Core/Manager/TransactionManager.swift
+++ b/PocketPulse/iOS/Core/Manager/TransactionManager.swift
@@ -1,0 +1,64 @@
+//
+//  TransactionManager.swift
+//  PocketPulse
+//
+//  Created by govardhan singh bhati on 24/08/25.
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK:- Transaction Manager
+/// A class responsible for handling all business logic related to transactions.
+///
+/// This centralized manager ensures that actions like deleting a transaction are handled
+/// consistently across the entire application.
+class TransactionManager {
+    
+    /// Deletes a transaction and correctly updates the balance of any linked account or card.
+    /// This method is static so it can be called from anywhere without needing an instance of the manager.
+    /// - Parameters:
+    ///   - transaction: The `TransactionModel` object to be deleted.
+    ///   - context: The SwiftData `ModelContext` to perform the deletion in.
+    static func delete(transaction: TransactionModel, in context: ModelContext) {
+        // Check if the transaction is linked to a bank account.
+        if let accountID = transaction.linkedAccountID {
+            // Find the specific account in the database.
+            if let account = findAccount(with: accountID, in: context) {
+                if transaction.type == .expense {
+                    account.balance += transaction.amount // Add the amount back for an expense.
+                } else {
+                    account.balance -= transaction.amount // Subtract the amount for an income.
+                }
+            }
+        // Check if the transaction is linked to a card.
+        } else if let cardID = transaction.linkedCardID {
+            // Find the specific card in the database.
+            if let card = findCard(with: cardID, in: context) {
+                // For a credit card expense, subtract the amount from the outstanding balance.
+                card.outstandingBalance = (card.outstandingBalance ?? 0) - transaction.amount
+            }
+        }
+        
+        // After updating any linked balances, delete the transaction itself.
+        context.delete(transaction)
+    }
+    
+    // MARK: - Private Helper Functions
+    
+    /// Fetches an `AccountModel` with a specific ID from the database.
+    private static func findAccount(with id: UUID, in context: ModelContext) -> AccountModel? {
+        let predicate = #Predicate<AccountModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+    
+    /// Fetches a `CardModel` with a specific ID from the database.
+    private static func findCard(with id: UUID, in context: ModelContext) -> CardModel? {
+        let predicate = #Predicate<CardModel> { $0.id == id }
+        var descriptor = FetchDescriptor(predicate: predicate)
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+}

--- a/PocketPulse/iOS/Features/Home/HomeView.swift
+++ b/PocketPulse/iOS/Features/Home/HomeView.swift
@@ -18,8 +18,11 @@ struct HomeView: View {
     @State private var showBalanceBreakdown = false
     @State private var transactionToDelete: TransactionModel?
     
-    @Query(sort: \AccountModel.name) private var accounts: [AccountModel]
-
+    @Query private var accounts: [AccountModel]
+    @Query private var cards: [CardModel]
+    @Query(sort: \TransactionModel.date, order: .reverse) private var transactions: [TransactionModel]
+    
+    
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
@@ -29,12 +32,13 @@ struct HomeView: View {
             }
             .padding(.vertical)
         }
-        .refreshable {
-            viewModel.fetchData(context: context)
-        }
-        .onAppear {
-            viewModel.fetchData(context: context)
-        }
+        
+        .onAppear(perform: updateViewModel)
+        
+        .onChange(of: accounts) { updateViewModel() }
+        .onChange(of: cards) { updateViewModel() }
+        .onChange(of: transactions) { updateViewModel() }
+        
         .deletionAlert(
             for: $transactionToDelete,
             ofType: .transaction(title: transactionToDelete?.title ?? "")
@@ -66,7 +70,7 @@ struct HomeView: View {
             }
         }
     }
-
+    
     // MARK: - Subviews
     private var balanceSection: some View {
         Button(action: {
@@ -95,7 +99,7 @@ struct HomeView: View {
                             .fontWeight(.semibold)
                     }
                     .frame(maxWidth: .infinity)
-
+                    
                     VStack {
                         Text("This Month's Expenses")
                             .font(.caption)
@@ -114,7 +118,7 @@ struct HomeView: View {
         .buttonStyle(.plain)
         .padding(.horizontal)
     }
-
+    
     @ViewBuilder
     private var cardCarouselSection: some View {
         VStack(alignment: .leading) {
@@ -129,7 +133,7 @@ struct HomeView: View {
                 }
             }
             .padding(.horizontal)
-
+            
             if viewModel.cards.isEmpty {
                 PlaceholderView(
                     imageName: "creditcard.fill",
@@ -158,7 +162,7 @@ struct HomeView: View {
             }
         }
     }
-
+    
     @ViewBuilder
     private var recentTransactionsSection: some View {
         VStack(alignment: .leading) {
@@ -181,7 +185,7 @@ struct HomeView: View {
                     subtitle: "Your recent income and expenses will appear here.",
                     buttonLabel: "Add a Transaction"
                 ) {}
-                .padding(.horizontal)
+                    .padding(.horizontal)
             } else {
                 List {
                     ForEach(viewModel.recentTransactions.prefix(10)) { transaction in
@@ -189,7 +193,7 @@ struct HomeView: View {
                             .swipeActions (edge: .trailing, allowsFullSwipe: true){
                                 Button(role: .destructive) {
                                     // This will now correctly trigger the alert
-                                     transactionToDelete = transaction
+                                    transactionToDelete = transaction
                                 } label: {
                                     Label("Delete", systemImage: "trash")
                                 }
@@ -201,5 +205,14 @@ struct HomeView: View {
                 .frame(height: CGFloat(viewModel.recentTransactions.prefix(10).count) * 80) // Adjust the height per row as needed
             }
         }
+    }
+    
+    // A helper function to avoid repeating the update call.
+    private func updateViewModel() {
+        viewModel.update(
+            accounts: accounts,
+            cards: cards,
+            transactions: transactions
+        )
     }
 }

--- a/PocketPulse/iOS/Features/Home/HomeView.swift
+++ b/PocketPulse/iOS/Features/Home/HomeView.swift
@@ -16,6 +16,7 @@ struct HomeView: View {
     @Environment(\.presentSheet) private var presentSheet
     
     @State private var showBalanceBreakdown = false
+    @State private var transactionToDelete: TransactionModel?
     
     @Query(sort: \AccountModel.name) private var accounts: [AccountModel]
 
@@ -33,6 +34,13 @@ struct HomeView: View {
         }
         .onAppear {
             viewModel.fetchData(context: context)
+        }
+        .deletionAlert(
+            for: $transactionToDelete,
+            ofType: .transaction(title: transactionToDelete?.title ?? "")
+        ) { item in
+            // Provide the specific deletion logic here, calling the TransactionManager.
+            TransactionManager.delete(transaction: item, in: context)
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -175,12 +183,22 @@ struct HomeView: View {
                 ) {}
                 .padding(.horizontal)
             } else {
-                VStack(spacing: 8) {
+                List {
                     ForEach(viewModel.recentTransactions.prefix(10)) { transaction in
                         TransactionRow(transaction: transaction)
+                            .swipeActions (edge: .trailing, allowsFullSwipe: true){
+                                Button(role: .destructive) {
+                                    // This will now correctly trigger the alert
+                                     transactionToDelete = transaction
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
                     }
                 }
-                .padding(.horizontal)
+                .listStyle(.plain)
+                // Give the list a fixed height to prevent it from taking over the screen
+                .frame(height: CGFloat(viewModel.recentTransactions.prefix(10).count) * 80) // Adjust the height per row as needed
             }
         }
     }

--- a/PocketPulse/iOS/Features/Home/HomeViewModel.swift
+++ b/PocketPulse/iOS/Features/Home/HomeViewModel.swift
@@ -17,27 +17,41 @@ class HomeViewModel: ObservableObject {
     @Published var recentTransactions: [TransactionModel] = []
     @Published var welcomeMessage: String = "Welcome!"
 
-    func fetchData(context: ModelContext) {
-        do {
-            let accounts = try context.fetch(FetchDescriptor<AccountModel>())
+//    func fetchData(context: ModelContext) {
+//        do {
+//            let accounts = try context.fetch(FetchDescriptor<AccountModel>())
+//            self.currentBalance = accounts.reduce(0) { $0 + $1.balance }
+//            self.cards = try context.fetch(FetchDescriptor<CardModel>())
+//            
+//            let transactionDescriptor = FetchDescriptor<TransactionModel>(sortBy: [SortDescriptor(\.date, order: .reverse)])
+//            let allTransactions = try context.fetch(transactionDescriptor)
+//            self.recentTransactions = allTransactions
+//            
+//            if !accounts.isEmpty || !allTransactions.isEmpty {
+//                self.welcomeMessage = "Welcome Back!"
+//            } else {
+//                self.welcomeMessage = "Welcome!"
+//            }
+//            
+//            calculateMonthlySummary(transactions: allTransactions)
+//        } catch {
+//            print("Failed to fetch data: \(error)")
+//        }
+//    }
+    
+    func update(accounts: [AccountModel], cards: [CardModel], transactions: [TransactionModel]) {
             self.currentBalance = accounts.reduce(0) { $0 + $1.balance }
-            self.cards = try context.fetch(FetchDescriptor<CardModel>())
+            self.cards = cards
+            self.recentTransactions = Array(transactions)
             
-            let transactionDescriptor = FetchDescriptor<TransactionModel>(sortBy: [SortDescriptor(\.date, order: .reverse)])
-            let allTransactions = try context.fetch(transactionDescriptor)
-            self.recentTransactions = allTransactions
-            
-            if !accounts.isEmpty || !allTransactions.isEmpty {
+            if !accounts.isEmpty || !transactions.isEmpty {
                 self.welcomeMessage = "Welcome Back!"
             } else {
                 self.welcomeMessage = "Welcome!"
             }
             
-            calculateMonthlySummary(transactions: allTransactions)
-        } catch {
-            print("Failed to fetch data: \(error)")
+            calculateMonthlySummary(transactions: transactions)
         }
-    }
 
     private func calculateMonthlySummary(transactions: [TransactionModel]) {
         let calendar = Calendar.current

--- a/PocketPulse/iOS/Features/Home/HomeViewModel.swift
+++ b/PocketPulse/iOS/Features/Home/HomeViewModel.swift
@@ -16,43 +16,21 @@ class HomeViewModel: ObservableObject {
     @Published var cards: [CardModel] = []
     @Published var recentTransactions: [TransactionModel] = []
     @Published var welcomeMessage: String = "Welcome!"
-
-//    func fetchData(context: ModelContext) {
-//        do {
-//            let accounts = try context.fetch(FetchDescriptor<AccountModel>())
-//            self.currentBalance = accounts.reduce(0) { $0 + $1.balance }
-//            self.cards = try context.fetch(FetchDescriptor<CardModel>())
-//            
-//            let transactionDescriptor = FetchDescriptor<TransactionModel>(sortBy: [SortDescriptor(\.date, order: .reverse)])
-//            let allTransactions = try context.fetch(transactionDescriptor)
-//            self.recentTransactions = allTransactions
-//            
-//            if !accounts.isEmpty || !allTransactions.isEmpty {
-//                self.welcomeMessage = "Welcome Back!"
-//            } else {
-//                self.welcomeMessage = "Welcome!"
-//            }
-//            
-//            calculateMonthlySummary(transactions: allTransactions)
-//        } catch {
-//            print("Failed to fetch data: \(error)")
-//        }
-//    }
     
     func update(accounts: [AccountModel], cards: [CardModel], transactions: [TransactionModel]) {
-            self.currentBalance = accounts.reduce(0) { $0 + $1.balance }
-            self.cards = cards
-            self.recentTransactions = Array(transactions)
-            
-            if !accounts.isEmpty || !transactions.isEmpty {
-                self.welcomeMessage = "Welcome Back!"
-            } else {
-                self.welcomeMessage = "Welcome!"
-            }
-            
-            calculateMonthlySummary(transactions: transactions)
+        self.currentBalance = accounts.reduce(0) { $0 + $1.balance }
+        self.cards = cards
+        self.recentTransactions = Array(transactions)
+        
+        if !accounts.isEmpty || !transactions.isEmpty {
+            self.welcomeMessage = "Welcome Back!"
+        } else {
+            self.welcomeMessage = "Welcome!"
         }
-
+        
+        calculateMonthlySummary(transactions: transactions)
+    }
+    
     private func calculateMonthlySummary(transactions: [TransactionModel]) {
         let calendar = Calendar.current
         guard let monthInterval = calendar.dateInterval(of: .month, for: Date()) else { return }

--- a/PocketPulse/iOS/Features/Statics/StaticsView.swift
+++ b/PocketPulse/iOS/Features/Statics/StaticsView.swift
@@ -1,12 +1,16 @@
 import SwiftUI
 import Charts
+import SwiftData
 
 struct StaticsView: View {
     @Environment(\.modelContext) private var context
     @StateObject private var viewModel = StaticsViewModel()
     
+    @Query(sort: \TransactionModel.date, order: .reverse) private var transactions: [TransactionModel]
+    
     @State private var selectedFilter: TimeFilter = .thisWeek
     @State private var showDatePicker = false
+    @State private var transactionToDelete: TransactionModel?
     
     // Date range for the custom filter
     @State private var customStartDate = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
@@ -23,7 +27,7 @@ struct StaticsView: View {
                     Spacer()
                     filterMenu
                 }
-                
+                .padding()
                 // MARK: Summary Cards
                 HStack(spacing: 16) {
                     StatCard(title: "Income", amount: viewModel.totalIncome, color: .green)
@@ -50,22 +54,30 @@ struct StaticsView: View {
                 // MARK: Transaction List
                 transactionListSection
             }
-            .padding()
+            
         }
-        .onAppear {
-            viewModel.loadData(context: context, filter: selectedFilter, startDate: customStartDate, endDate: customEndDate)
-        }
+        
+        .onAppear(perform: updateViewModel)
+        
+        .onChange(of: transactions) { updateViewModel() }
         .onChange(of: selectedFilter) {
             if selectedFilter == .custom {
                 showDatePicker = true
             } else {
-                viewModel.loadData(context: context, filter: selectedFilter, startDate: customStartDate, endDate: customEndDate)
+                updateViewModel()
             }
         }
         .sheet(isPresented: $showDatePicker) {
             CustomDatePickerView(startDate: $customStartDate, endDate: $customEndDate) {
-                viewModel.loadData(context: context, filter: .custom, startDate: customStartDate, endDate: customEndDate)
+                updateViewModel()
             }
+        }
+        .deletionAlert(
+            for: $transactionToDelete,
+            ofType: .transaction(title: transactionToDelete?.title ?? "")
+        ) { item in
+            // Provide the specific deletion logic here, calling the TransactionManager.
+            TransactionManager.delete(transaction: item, in: context)
         }
     }
     
@@ -114,26 +126,47 @@ struct StaticsView: View {
                 .font(.headline)
             AnalyticsPieChartView(expenses: viewModel.categoryStats)
         }
+        .padding()
     }
     
+    @ViewBuilder
     private var transactionListSection: some View {
         VStack(alignment: .leading) {
             Text("Transactions")
                 .font(.headline)
-            
+                .padding()
             if viewModel.filteredTransactions.isEmpty {
                 Text("No transactions in this period.")
                     .foregroundColor(.secondary)
                     .padding()
             } else {
-                // We use a VStack here instead of a List to avoid nested scrolling issues.
-                VStack(spacing: 8) {
+                List {
                     ForEach(viewModel.filteredTransactions) { transaction in
                         TransactionRow(transaction: transaction)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    transactionToDelete = transaction
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
                     }
                 }
+                .listStyle(.plain)
+                // Give the list a dynamic height based on its content
+                .frame(height: CGFloat(viewModel.filteredTransactions.count) * 80) 
             }
         }
+    }
+    
+    // A helper function to avoid repeating the update call.
+    private func updateViewModel() {
+        viewModel.update(
+            transactions: transactions,
+            filter: selectedFilter,
+            startDate: customStartDate,
+            endDate: customEndDate
+        )
     }
 }
 

--- a/PocketPulse/iOS/Features/Statics/StaticsViewModel.swift
+++ b/PocketPulse/iOS/Features/Statics/StaticsViewModel.swift
@@ -17,49 +17,42 @@ class StaticsViewModel: ObservableObject {
     @Published var filteredTransactions: [TransactionModel] = []
     @Published var categoryStats: [ExpenseCategoryStat] = []
     
-    func loadData(context: ModelContext, filter: TimeFilter, startDate: Date, endDate: Date) {
-        do {
-            let allTransactions = try context.fetch(FetchDescriptor<TransactionModel>())
-            
-            // 1. Filter transactions based on the selected time range
-            let dateFilteredTxns = allTransactions.filter { txn in
-                switch filter {
-                case .thisWeek, .thisMonth:
-                    return filter.contains(txn.date)
-                case .custom:
-                    // Ensure the range is inclusive of the end date
-                    let endOfDay = Calendar.current.startOfDay(for: endDate).addingTimeInterval(24*60*60-1)
-                    return txn.date >= Calendar.current.startOfDay(for: startDate) && txn.date <= endOfDay
-                }
-            }
-            self.filteredTransactions = dateFilteredTxns.sorted(by: { $0.date > $1.date })
-            
-            // 2. Calculate total income and expense for the period
-            self.totalIncome = dateFilteredTxns.filter { $0.type == .income }.reduce(0) { $0 + $1.amount }
-            self.totalExpense = dateFilteredTxns.filter { $0.type == .expense }.reduce(0) { $0 + $1.amount }
-            
-            // 3. Aggregate data for the bar chart
-            let incomeGrouped = Dictionary(grouping: dateFilteredTxns.filter { $0.type == .income }) { Calendar.current.startOfDay(for: $0.date) }
-            let expenseGrouped = Dictionary(grouping: dateFilteredTxns.filter { $0.type == .expense }) { Calendar.current.startOfDay(for: $0.date) }
-            
-            var combinedData: [DailyTotal] = []
-            incomeGrouped.forEach { date, transactions in
-                combinedData.append(DailyTotal(date: date, amount: transactions.reduce(0) { $0 + $1.amount }, type: .income))
-            }
-            expenseGrouped.forEach { date, transactions in
-                combinedData.append(DailyTotal(date: date, amount: transactions.reduce(0) { $0 + $1.amount }, type: .expense))
-            }
-            self.graphData = combinedData.sorted { $0.date < $1.date }
-            
-            // 4. Calculate spending by category for the pie chart
-            let expenseTxns = dateFilteredTxns.filter { $0.type == .expense }
-            let categoryGrouped = Dictionary(grouping: expenseTxns, by: { $0.category })
-            self.categoryStats = categoryGrouped.map { key, txns in
-                ExpenseCategoryStat(name: key.displayName, amount: txns.reduce(0) { $0 + $1.amount }, color: .random)
-            }.sorted(by: { $0.amount > $1.amount })
-            
-        } catch {
-            print("Failed to load statistics data: \(error)")
-        }
-    }
+    func update(transactions: [TransactionModel], filter: TimeFilter, startDate: Date? = nil, endDate: Date? = nil) {
+          // 1. Filter transactions based on the selected time range
+          let dateFilteredTxns = transactions.filter { txn in
+              switch filter {
+              case .thisWeek, .thisMonth:
+                  return filter.contains(txn.date)
+              case .custom:
+                  guard let start = startDate, let end = endDate else { return false }
+                  let endOfDay = Calendar.current.startOfDay(for: end).addingTimeInterval(24*60*60-1)
+                  return txn.date >= Calendar.current.startOfDay(for: start) && txn.date <= endOfDay
+              }
+          }
+          self.filteredTransactions = dateFilteredTxns // No need to sort here, @Query already did it
+          
+          // 2. Calculate total income and expense for the period
+          self.totalIncome = dateFilteredTxns.filter { $0.type == .income }.reduce(0) { $0 + $1.amount }
+          self.totalExpense = dateFilteredTxns.filter { $0.type == .expense }.reduce(0) { $0 + $1.amount }
+
+          // 3. Aggregate data for the bar chart
+          let incomeGrouped = Dictionary(grouping: dateFilteredTxns.filter { $0.type == .income }) { Calendar.current.startOfDay(for: $0.date) }
+          let expenseGrouped = Dictionary(grouping: dateFilteredTxns.filter { $0.type == .expense }) { Calendar.current.startOfDay(for: $0.date) }
+          
+          var combinedData: [DailyTotal] = []
+          incomeGrouped.forEach { date, transactions in
+              combinedData.append(DailyTotal(date: date, amount: transactions.reduce(0) { $0 + $1.amount }, type: .income))
+          }
+          expenseGrouped.forEach { date, transactions in
+              combinedData.append(DailyTotal(date: date, amount: transactions.reduce(0) { $0 + $1.amount }, type: .expense))
+          }
+          self.graphData = combinedData.sorted { $0.date < $1.date }
+          
+          // 4. Calculate spending by category for the pie chart
+          let expenseTxns = dateFilteredTxns.filter { $0.type == .expense }
+          let categoryGrouped = Dictionary(grouping: expenseTxns, by: { $0.category })
+          self.categoryStats = categoryGrouped.map { key, txns in
+              ExpenseCategoryStat(name: key.displayName, amount: txns.reduce(0) { $0 + $1.amount }, color: .random)
+          }.sorted(by: { $0.amount > $1.amount })
+      }
 }

--- a/PocketPulse/iOS/Features/Transaction/TransactionListView.swift
+++ b/PocketPulse/iOS/Features/Transaction/TransactionListView.swift
@@ -9,12 +9,32 @@
 import SwiftUI
 import SwiftData
 
+// MARK: - Transaction List View
 struct TransactionListView: View {
+    @Environment(\.modelContext) private var context
     @Query(sort: \TransactionModel.date, order: .reverse) private var transactions: [TransactionModel]
+    
+    @State private var transactionToDelete: TransactionModel?
+
     var body: some View {
         List(transactions) { transaction in
             TransactionRow(transaction: transaction)
+                .swipeActions {
+                    Button(role: .destructive) {
+                        transactionToDelete = transaction
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
         }
+        .listStyle(.plain)
         .navigationTitle("All Transactions")
+        .deletionAlert(
+            for: $transactionToDelete,
+            ofType: .transaction(title: transactionToDelete?.title ?? "")
+        ) { item in
+            // Provide the specific deletion logic here, calling the TransactionManager.
+            TransactionManager.delete(transaction: item, in: context)
+        }
     }
 }

--- a/PocketPulse/iOS/UI/Components/DeletionAlert.swift
+++ b/PocketPulse/iOS/UI/Components/DeletionAlert.swift
@@ -1,0 +1,93 @@
+//
+//  DeletionAlert.swift
+//  PocketPulse
+//
+//  Created by govardhan singh bhati on 24/08/25.
+//
+
+import SwiftUI
+import SwiftData
+
+// MARK: - Generic Deletion Alert
+/// An enum to define the type of item being deleted.
+/// This allows the alert to show a specific, context-aware message.
+enum DeletableItemType {
+    case transaction(title: String)
+    case account(name: String)
+    case card(name: String)
+    case bill(title: String)
+    case borrowLend(name: String)
+    
+    /// The title for the alert, based on the item type.
+    var alertTitle: String {
+        switch self {
+        case .transaction: return "Delete Transaction?"
+        case .account: return "Delete Account?"
+        case .card: return "Delete Card?"
+        case .bill: return "Delete Bill?"
+        case .borrowLend: return "Delete Entry?"
+        }
+    }
+    
+    /// The detailed message for the alert, warning the user about the action.
+    var alertMessage: String {
+        switch self {
+        case .transaction(let title):
+            return "Are you sure you want to delete the transaction for \"\(title)\"? This action cannot be undone."
+        case .account(let name):
+            return "Are you sure you want to delete the account named \"\(name)\"? All associated data will be lost."
+        case .card(let name):
+            return "Are you sure you want to delete the card for \"\(name)\"?"
+        case .bill(let title):
+            return "Are you sure you want to delete the bill for \"\(title)\"?"
+        case .borrowLend(let name):
+            return "Are you sure you want to delete the entry for \"\(name)\"?"
+        }
+    }
+}
+
+/// A generic view modifier for presenting a deletion confirmation alert.
+/// It uses a callback closure to let the calling view handle the actual deletion logic.
+struct DeletionAlert<T: Identifiable>: ViewModifier {
+    /// A binding to the optional item that the view wants to delete.
+    @Binding var itemToDelete: T?
+    /// The specific type of item, used to configure the alert's title and message.
+    let itemType: DeletableItemType
+    
+    /// A closure that is executed when the user confirms the deletion.
+    /// The view that uses this modifier is responsible for providing the deletion logic.
+    let onDelete: (T) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .alert(
+                itemType.alertTitle,
+                isPresented: .constant(itemToDelete != nil),
+                presenting: itemToDelete
+            ) { item in
+                Button("Delete", role: .destructive) {
+                    onDelete(item)
+                    itemToDelete = nil
+                }
+                Button("Cancel", role: .cancel) { itemToDelete = nil }
+            } message: { _ in
+                Text(itemType.alertMessage)
+            }
+    }
+}
+
+/// An extension on `View` to make applying the `DeletionAlert` modifier cleaner.
+extension View {
+    /// Applies a modifier to the view that presents a standardized deletion confirmation alert.
+    /// - Parameters:
+    ///   - for: A binding to the optional item that should be deleted.
+    ///   - ofType: The `DeletableItemType` used to configure the alert's title and message.
+    ///   - onDelete: A closure that contains the specific logic to execute upon deletion.
+    func deletionAlert<T: Identifiable>(
+        for item: Binding<T?>,
+        ofType type: DeletableItemType,
+        onDelete: @escaping (T) -> Void
+    ) -> some View {
+        self.modifier(DeletionAlert(itemToDelete: item, itemType: type, onDelete: onDelete))
+    }
+}


### PR DESCRIPTION
feat(Statistics): Refactor to be reactive and add deletion

- The StaticsView now observes changes to transactions directly using @Query and updates the ViewModel via .onChange, removing the need for manual data fetching.
- Added swipe-to-delete functionality to the transaction list within the StaticsView.
- The deletion action uses the reusable transactionDeletionAlert modifier, which correctly calls the TransactionManager to reverse the transaction's financial impact.

Closes #8